### PR TITLE
Replace deprecated function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ This is a demo of using pyqt5 and QChart for show linechart in realtime applicat
 
 ## update rate
 The elapsed time of each update function is about 0.02-0.024 second, so the refresh frequency should be less than 40Hz.
+
+## requirements
+
+ - [PyQt5](https://pypi.org/project/PyQt5/) 
+ - [PyQtChart](https://pypi.org/project/PyQtChart/)

--- a/lineChart.py
+++ b/lineChart.py
@@ -142,10 +142,10 @@ class ThemeWidget(QWidget):
 
     def onTimerOut(self):
         # print('time out')
-        start = time.clock()
+        start = time.process_time()
         self.myChart.handleUpdate()
         QApplication.processEvents()
-        elapsed = (time.clock() - start)
+        elapsed = (time.process_time() - start)
         print("Time used: %.3fs" % elapsed)
 
     def generateRandomData(self, listCount, valueMax, valueCount):


### PR DESCRIPTION
The code was using Time.clock(), that as noted [here](https://stackoverflow.com/questions/58569361/attributeerror-module-time-has-no-attribute-clock-in-python-3-8) has been removed from python 3.8.

I replaced it, to make the code work with the latest version of python.

I also updated the readme to include the dependencies